### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # repo_1
+
+Pr to test field `merged_by`. Looks like , it is not present when using list_pulls but is available when retriveing pull by `id` and that needs additional call


### PR DESCRIPTION
Pr to test field `merged_by`. Looks like , it is not present when using list_pulls but is available when retriveing pull by `id` and that needs additional call